### PR TITLE
fix(url-utils): replace spaces with hyphens in tag URLs

### DIFF
--- a/src/pages/archive/tag/[tag].astro
+++ b/src/pages/archive/tag/[tag].astro
@@ -36,7 +36,7 @@ export async function getStaticPaths() {
 
 	const standardPaths = allTagsArray.map((tag) => ({
 		params: {
-			tag: encodePathSegment(tag),
+			tag: encodePathSegment(tag).replace(/%20/g, "-"),
 		},
 		props: {
 			decodedTag: tag,

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -21,7 +21,7 @@ export function getTagUrl(tag: string): string {
 	if (!tag) return url("/archive/tag/");
 
 	// use common encoding function
-	const encodedTag = encodePathSegment(tag);
+	const encodedTag = encodePathSegment(tag).replace(/%20/g, "-");
 	const tagUrl = `/archive/tag/${encodedTag}/`;
 	console.log(`Generating URL for tag "${tag.trim()}" => "${tagUrl}"`);
 	return url(tagUrl);


### PR DESCRIPTION
更新了标签 URL 的生成逻辑，将标签中的空格替换为连字符，以确保 URL 的一致性和可读性。